### PR TITLE
feat: destinations dynamiques

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>STEpe v1.4.2 VERIFY</title>
+    <title>STEpe v1.5.0 RELEVAGE</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,14 @@ import { toast } from 'react-toastify';
 
 let backupInterval = 30 * 1000; //30 * 1000 ms = 30s
 
-function init_cata() {	
+function init_affectation() {
+	const savedAffectation = window.localStorage.getItem("local_affectation");
+	if(savedAffectation) {
+		store.dispatch(DataAction.load_affectation(savedAffectation));
+	}
+}
+
+function init_cata() {
 	const Init_catalogDATAS = window.localStorage.getItem("local_catalog");
 	if(Init_catalogDATAS) {
 		store.dispatch(DataAction.loaded_catalog(Init_catalogDATAS));
@@ -35,11 +42,13 @@ function init_tally(){
 		store.dispatch(DataAction.save_previous_qtt());
 		store.dispatch(DataAction.save_previous_tons());
 		store.dispatch(DataAction.save_maxi_tons());
+		store.dispatch(DataAction.save_affectation());
 		toast.warning('AutoSave tally', { position: toast.POSITION.BOTTOM_LEFT, autoClose: 500 })
-	}, 
+	},
 	backupInterval);
 }
 
+init_affectation();
 init_cata();
 init_tally();
 

--- a/src/components/AffectationManager.tsx
+++ b/src/components/AffectationManager.tsx
@@ -1,82 +1,140 @@
 import React, { useState } from "react";
-import { useDispatch } from "react-redux";
-import { Modal, Button } from "react-bootstrap";
-import DataAction from "../stores/dataS/DataAction"; // Assurez-vous que le chemin est correct
+import { useDispatch, useSelector } from "react-redux";
+import { Button } from "react-bootstrap";
+import DataAction from "../stores/dataS/DataAction";
+import { RootState } from "../stores/rootStore";
+import { AffectationItem } from "../stores/dataS/DataReducer";
 
-interface Affectation {
-    name: string;
-    color: string;
-    index: number;
-}
-interface affectationItem {
-    name: string;   
-    color: string;
-}
-
-interface AffectationManagerProps {
-    affectation: Affectation[];
-    setAffectation: React.Dispatch<React.SetStateAction<Affectation[]>>; // Ajout de setAffectation
-}
-
-// Fonction pour générer une couleur aléatoire entre bleu et vert au format hexadécimal
 const generateRandomBlueGreenColor = (): string => {
-    const r = Math.floor(Math.random() * 50); // Rouge faible (0-50)
-    const g = Math.floor(150 + Math.random() * 105); // Vert moyen à élevé (150-255)
-    const b = Math.floor(150 + Math.random() * 105); // Bleu moyen à élevé (150-255)
-
-    // Convertir les valeurs RGB en hexadécimal
+    const r = Math.floor(Math.random() * 50);
+    const g = Math.floor(150 + Math.random() * 105);
+    const b = Math.floor(150 + Math.random() * 105);
     const toHex = (value: number) => value.toString(16).padStart(2, "0");
     return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
 };
 
-const AffectationManager: React.FC<AffectationManagerProps> = ({ affectation, setAffectation }) => {
+export default function AffectationManager() {
     const dispatch = useDispatch();
+    const affectation = useSelector<RootState, AffectationItem[]>(
+        (state) => state.dataSS.affectationList
+    );
 
     const [newName, setNewName] = useState("");
-    const [newColor, setNewColor] = useState(generateRandomBlueGreenColor()); // Initialiser avec une couleur aléatoire
+    const [newColor, setNewColor] = useState(generateRandomBlueGreenColor());
+    const [editingName, setEditingName] = useState<string | null>(null);
+    const [editValue, setEditValue] = useState("");
 
     const addAffectation = () => {
+        const trimmed = newName.trim();
+        if (!trimmed) return;
+        if (affectation.some(a => a.name.toLowerCase() === trimmed.toLowerCase())) return;
         const newIndex = affectation.length;
-        const newAffectation = [...affectation, { name: newName, color: newColor, index: newIndex }];
-        setAffectation(newAffectation);
-        dispatch(DataAction.updateAffectation(newAffectation)); // Met à jour Redux
+        const updated = [...affectation, { name: trimmed, color: newColor, index: newIndex }];
+        dispatch(DataAction.updateAffectation(updated));
+        dispatch(DataAction.save_affectation());
         setNewName("");
         setNewColor(generateRandomBlueGreenColor());
     };
 
     const removeAffectation = (name: string) => {
-        const updatedAffectation = affectation.filter((a) => a.name !== name);
-        setAffectation(updatedAffectation);
-        dispatch(DataAction.updateAffectation(updatedAffectation)); // Met à jour Redux
+        if (name === "stock") return;
+        const updated = affectation.filter((a) => a.name !== name);
+        dispatch(DataAction.updateAffectation(updated));
+        dispatch(DataAction.save_affectation());
+    };
+
+    const startRename = (name: string) => {
+        if (name === "stock") return;
+        setEditingName(name);
+        setEditValue(name);
+    };
+
+    const confirmRename = () => {
+        if (!editingName) return;
+        const trimmed = editValue.trim();
+        if (!trimmed || trimmed === editingName) {
+            setEditingName(null);
+            return;
+        }
+        if (affectation.some(a => a.name.toLowerCase() === trimmed.toLowerCase())) {
+            setEditingName(null);
+            return;
+        }
+        dispatch(DataAction.renameAffectation(editingName, trimmed));
+        dispatch(DataAction.save_affectation());
+        setEditingName(null);
+    };
+
+    const handleRenameKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === "Enter") confirmRename();
+        if (e.key === "Escape") setEditingName(null);
+    };
+
+    const changeColor = (name: string, color: string) => {
+        const updated = affectation.map(a =>
+            a.name === name ? { ...a, color } : a
+        );
+        dispatch(DataAction.updateAffectation(updated));
+        dispatch(DataAction.save_affectation());
     };
 
     return (
         <div>
-            <h3>Gestion des Affectations</h3>
             <table style={{ width: "100%", borderCollapse: "collapse" }}>
                 <thead>
                     <tr>
-                        <th style={{ width: "40%", border: "1px solid #ddd", padding: "8px" }}>Nom</th>
-                        <th style={{ width: "40%", border: "1px solid #ddd", padding: "8px" }}>Couleur</th>
-                        <th style={{ width: "20%", border: "1px solid #ddd", padding: "8px" }}>Actions</th>
+                        <th style={{ width: "35%", border: "1px solid #ddd", padding: "8px" }}>Nom</th>
+                        <th style={{ width: "15%", border: "1px solid #ddd", padding: "8px" }}>Couleur</th>
+                        <th style={{ width: "50%", border: "1px solid #ddd", padding: "8px" }}>Actions</th>
                     </tr>
                 </thead>
                 <tbody>
                     {affectation.map((a) => (
                         <tr key={a.name}>
-                            <td style={{ border: "1px solid #ddd", padding: "8px" }}>{a.name}</td>
                             <td style={{ border: "1px solid #ddd", padding: "8px" }}>
-                                <div
-                                    style={{
-                                        width: "20px",
-                                        height: "20px",
-                                        backgroundColor: a.color,
-                                        border: "1px solid #000",
-                                    }}
-                                ></div>
+                                {editingName === a.name ? (
+                                    <input
+                                        type="text"
+                                        value={editValue}
+                                        onChange={(e) => setEditValue(e.target.value)}
+                                        onBlur={confirmRename}
+                                        onKeyDown={handleRenameKeyDown}
+                                        maxLength={10}
+                                        autoFocus
+                                        style={{ width: "100%" }}
+                                    />
+                                ) : (
+                                    a.name
+                                )}
                             </td>
                             <td style={{ border: "1px solid #ddd", padding: "8px" }}>
-                                <button onClick={() => removeAffectation(a.name)}>Supprimer</button>
+                                <input
+                                    type="color"
+                                    value={a.color}
+                                    onChange={(e) => changeColor(a.name, e.target.value)}
+                                    style={{ width: "30px", height: "24px", padding: "0", border: "none", cursor: "pointer" }}
+                                />
+                            </td>
+                            <td style={{ border: "1px solid #ddd", padding: "8px" }}>
+                                {a.name !== "stock" && (
+                                    <>
+                                        <Button
+                                            size="sm"
+                                            variant="outline-primary"
+                                            onClick={() => startRename(a.name)}
+                                            style={{ marginRight: "4px" }}
+                                        >
+                                            Renommer
+                                        </Button>
+                                        <Button
+                                            size="sm"
+                                            variant="outline-danger"
+                                            onClick={() => removeAffectation(a.name)}
+                                        >
+                                            Supprimer
+                                        </Button>
+                                    </>
+                                )}
                             </td>
                         </tr>
                     ))}
@@ -85,10 +143,11 @@ const AffectationManager: React.FC<AffectationManagerProps> = ({ affectation, se
             <div style={{ marginTop: "20px", display: "flex", alignItems: "center", gap: "10px" }}>
                 <input
                     type="text"
-                    placeholder="Nom"
+                    placeholder="Nouveau nom"
                     maxLength={10}
                     value={newName}
                     onChange={(e) => setNewName(e.target.value)}
+                    onKeyDown={(e) => e.key === "Enter" && addAffectation()}
                     style={{ width: "150px" }}
                 />
                 <input
@@ -97,39 +156,10 @@ const AffectationManager: React.FC<AffectationManagerProps> = ({ affectation, se
                     onChange={(e) => setNewColor(e.target.value)}
                     style={{ width: "40px", height: "28px", padding: "0", border: "none" }}
                 />
-                <button onClick={addAffectation} disabled={!newName.trim()}>
+                <Button onClick={addAffectation} disabled={!newName.trim()}>
                     Ajouter
-                </button>
+                </Button>
             </div>
         </div>
     );
-};
-
-const AffectationModal: React.FC<{
-    showAffectationManager: boolean;
-    handleCloseAffectationManager: () => void;
-    affectation: Affectation[];
-    setAffectation: React.Dispatch<React.SetStateAction<Affectation[]>>;
-}> = ({ showAffectationManager, handleCloseAffectationManager, affectation, setAffectation }) => {
-    return (
-        <Modal show={showAffectationManager} onHide={handleCloseAffectationManager}>
-            <Modal.Header closeButton>
-                <Modal.Title>Gestion des Affectations</Modal.Title>
-            </Modal.Header>
-            <Modal.Body>
-                <AffectationManager
-                    affectation={affectation}
-                    setAffectation={setAffectation} // Passer setAffectation comme prop
-                />
-            </Modal.Body>
-            <Modal.Footer>
-                <Button variant="secondary" onClick={handleCloseAffectationManager}>
-                    Fermer
-                </Button>
-            </Modal.Footer>
-        </Modal>
-    );
-};
-
-export default AffectationManager;
-export { AffectationModal };
+}

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -21,7 +21,8 @@ import {RootState} from "../stores/rootStore";
 import {export_stepe_catalog_Data} from "../stores/dataS/DataReducer";
 import DebouncedInput from "./debounceInput";
 import DataAction from "../stores/dataS/DataAction";
-import {colors, affectation as initialAffectation, HEADER} from "../utils/destination";
+import {HEADER} from "../utils/destination";
+import {AffectationItem} from "../stores/dataS/DataReducer";
 import Filter, {fuzzyFilter} from "./filter";
 import './index-tanstack.css'
 import { toast } from "react-toastify";
@@ -206,7 +207,7 @@ const row = {
 //***********************************************************************/
 export default function DataTable() {
     const dispatch = useDispatch();
-    const [affectation, setAffectation] = useState(initialAffectation); // Utiliser les données initiales
+    const affectation = useSelector<RootState, AffectationItem[]>((state) => state.dataSS.affectationList);
     const [PickerColorForSelectedCale, setPickerColorForSelectedCale] = useState<{ [key: string]: string }>({});
     const [newSelectedCale, setnewSelectedCale] = useState<string>('');
     const [newColor, setNewColor] = useState<string>('');
@@ -540,10 +541,7 @@ export default function DataTable() {
                     <Modal.Title>Gestion des Affectations</Modal.Title>
                 </Modal.Header>
                 <Modal.Body>
-                    <AffectationManager
-                        affectation={affectation}
-                        setAffectation={setAffectation}
-                    />
+                    <AffectationManager />
                 </Modal.Body>
                 <Modal.Footer>
                     <Button variant="secondary" onClick={handleCloseAffectationManager}>

--- a/src/components/statistics.tsx
+++ b/src/components/statistics.tsx
@@ -6,8 +6,7 @@ import { export_stepe_catalog_Data } from "../stores/dataS/DataReducer";
 import { Table } from "react-bootstrap";
 import React, { useState, useEffect } from 'react';
 
-import { affectation} from "../utils/destination";
-import {colors, affectation as initialAffectation, HEADER} from "../utils/destination";
+import { AffectationItem } from "../stores/dataS/DataReducer";
 
 
 // import { updateAffectationVisibility } from '../stores/data/destinationActions';
@@ -38,14 +37,7 @@ export default function Statistics() {
 	const [maxi_Value_TO, set_maxi_Values] 			 = useState<{ [key: string]: { maxi_To: string      } }>({});
 
 
-	const [affectation, setAffectation] = useState(initialAffectation); // Utiliser les données initiales
-	
-	// Define the AffectationItem type
-	type AffectationItem = {
-		key: string;
-		name: string;
-		color: string;
-	};
+	const affectation = useSelector<RootState, AffectationItem[]>((state) => state.dataSS.affectationList);
 
 
     const selectedColors = useSelector((state: RootState) => state.dataSS.pickerColors);

--- a/src/stores/dataS/DataAction.ts
+++ b/src/stores/dataS/DataAction.ts
@@ -40,9 +40,24 @@ export default class DataAction {
 	public static CHANGE_MAXI_TONS = "DataAction.CHANGE_MAXI_TONS";
 
 	public static UPDATE_AFFECTATION = "DataAction.UPDATE_AFFECTATION";
+	public static RENAME_AFFECTATION = "DataAction.RENAME_AFFECTATION";
+	public static SAVE_AFFECTATION = "DataAction.SAVE_AFFECTATION";
+	public static LOAD_AFFECTATION = "DataAction.LOAD_AFFECTATION";
 
 	public static updateAffectation(affectation: any[]): AnyAction {
 		return { type: DataAction.UPDATE_AFFECTATION, payload: affectation };
+	}
+
+	public static renameAffectation(oldName: string, newName: string): AnyAction {
+		return { type: DataAction.RENAME_AFFECTATION, payload: { oldName, newName } };
+	}
+
+	public static save_affectation(): AnyAction {
+		return { type: DataAction.SAVE_AFFECTATION };
+	}
+
+	public static load_affectation(data: string): AnyAction {
+		return { type: DataAction.LOAD_AFFECTATION, payload: JSON.parse(data) };
 	}
 
 	public static change_checkbox_state(changecheckboxstate: { [destination: string]: boolean }): AnyAction {

--- a/src/stores/dataS/DataReducer.ts
+++ b/src/stores/dataS/DataReducer.ts
@@ -1,8 +1,7 @@
 import { AnyAction } from "redux";
 import DataAction from "./DataAction";
 import {Reducer} from "@reduxjs/toolkit";
-import { colors } from "../../utils/destination";
-import { stat } from "fs";
+import { colors, affectation as defaultAffectation } from "../../utils/destination";
 
 export type export_stepe_catalog_Data = {
     rank: number
@@ -20,12 +19,17 @@ export type export_stepe_tally_Data = {
     tally_Max: string
 }
 
+export type AffectationItem = {
+    name: string;
+    color: string;
+    index: number;
+}
+
 interface Interface_stepe_state {
     catalog_data_state: export_stepe_catalog_Data[];
     tally_data_state: export_stepe_tally_Data[];
-    
-    affectation: string;
-    initialAffectation: string;
+
+    affectationList: AffectationItem[];
 
     selectedCale: string;
     selectedPrepa: string;
@@ -55,9 +59,8 @@ interface Interface_stepe_state {
 const initial_stepe_Data_State: Interface_stepe_state = {
     catalog_data_state: [],
     tally_data_state: [],
-    
-    affectation: "",
-    initialAffectation: "",
+
+    affectationList: defaultAffectation,
 
     selectedCale: "stock",
     selectedPrepa: "_",
@@ -274,7 +277,37 @@ export const dataReducer: Reducer<Interface_stepe_state> = (state = initial_step
             case DataAction.UPDATE_AFFECTATION:
                 return {
                     ...state,
-                    affectation: action.payload,
+                    affectationList: action.payload,
+                };
+
+            case DataAction.RENAME_AFFECTATION: {
+                const { oldName, newName } = action.payload;
+                return {
+                    ...state,
+                    affectationList: state.affectationList.map(a =>
+                        a.name === oldName ? { ...a, name: newName } : a
+                    ),
+                    catalog_data_state: state.catalog_data_state.map(row =>
+                        row.destination === oldName ? { ...row, destination: newName } : row
+                    ),
+                    selectedCale: state.selectedCale === oldName ? newName : state.selectedCale,
+                    pickerColors: Object.fromEntries(
+                        Object.entries(state.pickerColors).map(([k, v]) =>
+                            k === oldName ? [newName, v] : [k, v]
+                        )
+                    ),
+                    saved_catalog_status: false,
+                };
+            }
+
+            case DataAction.SAVE_AFFECTATION:
+                window.localStorage.setItem("local_affectation", JSON.stringify(state.affectationList));
+                return state;
+
+            case DataAction.LOAD_AFFECTATION:
+                return {
+                    ...state,
+                    affectationList: action.payload,
                 };
 
             default:


### PR DESCRIPTION
## Summary
- La liste des destinations (stock, H1, H2...) est maintenant dynamique : on peut **ajouter**, **supprimer**, **renommer** et **changer la couleur** depuis le menu "Gestion des Affectations"
- Les destinations sont stockees dans Redux et persistees dans localStorage (survivent au rechargement)
- Le renommage met a jour automatiquement toutes les lignes du catalogue
- "stock" est protege contre la suppression

## Test plan
- [ ] Ouvrir le dropdown destination et selectionner "Gestion des Affectations"
- [ ] Ajouter une nouvelle destination avec un nom et une couleur
- [ ] Verifier qu'elle apparait dans le dropdown et dans les statistiques
- [ ] Renommer une destination et verifier que les lignes du catalogue sont mises a jour
- [ ] Supprimer une destination
- [ ] Verifier que "stock" ne peut pas etre supprime/renomme
- [ ] Recharger la page et verifier que les destinations custom sont conservees

🤖 Generated with [Claude Code](https://claude.com/claude-code)